### PR TITLE
Fix 8075 TextTable borders render incorrectly in browser

### DIFF
--- a/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.java.gradle.kts
+++ b/build-logic/project-plugins/src/main/kotlin/com.hedera.hashgraph.java.gradle.kts
@@ -140,7 +140,7 @@ testing {
                     }
                     // Increase the heap size for the unit tests
                     maxHeapSize = "4096m"
-                    jvmArgs("-XX:ActiveProcessorCount=7")
+                    jvmArgs("-XX:ActiveProcessorCount=7", "-Dfile.encoding=UTF-8")
                     // Can be useful to set in some cases
                     // testLogging.showStandardStreams = true
                 }
@@ -159,7 +159,7 @@ testing {
 
                 useJUnitPlatform { includeTags("HAMMER") }
                 maxHeapSize = "8g"
-                jvmArgs("-XX:ActiveProcessorCount=7")
+                jvmArgs("-XX:ActiveProcessorCount=7", "-Dfile.encoding=UTF-8")
             }
 
             tasks.register<Test>("performanceTest") {
@@ -175,7 +175,7 @@ testing {
                 setForkEvery(1)
                 minHeapSize = "2g"
                 maxHeapSize = "16g"
-                jvmArgs("-XX:ActiveProcessorCount=7", "-XX:+UseZGC")
+                jvmArgs("-XX:ActiveProcessorCount=7", "-XX:+UseZGC", "-Dfile.encoding=UTF-8")
             }
         }
     }


### PR DESCRIPTION
**Description:**
This PR changes the following:

- Set UTF-8 as Default Encoding for JVM in Tests

Set JVM encoding to UTF-8 in test tasks, ensuring consistent and unambiguous encoding in generated HTML reports. This change eliminates default or ambiguous encoding behaviors, guaranteeing uniformity in the testing and report generation process.

**Related issue(s):**
Closes ###